### PR TITLE
Build Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ go_import_path: github.com/emccode/gournal
 
 language: go
 go:
-  - 1.4.3
   - 1.5.4
   - 1.6.3
+  - 1.7
   - tip
 
 os:
@@ -14,6 +14,7 @@ os:
 matrix:
   allow_failures:
     - go: tip
+  fast_finish: true
 
 before_install:
   - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ else
 GOVERSION := $(shell go version | awk '{print $$3}' | cut -c3-)
 endif
 
-ifeq (1.6.3,$(TRAVIS_GO_VERSION))
+ifeq (1.7,$(TRAVIS_GO_VERSION))
 ifeq (linux,$(TRAVIS_OS_NAME))
 COVERAGE_ENABLED := 1
 endif
@@ -585,6 +585,7 @@ run-examples:
 	@echo EXAMPLE 1 && $(MAKE) run-example-1 && echo
 	@echo EXAMPLE 2 && $(MAKE) run-example-2 && echo
 	@echo EXAMPLE 3 && $(MAKE) run-example-3 && echo
+	@echo EXAMPLE 4 && $(MAKE) run-example-4 && echo
 
 
 ################################################################################


### PR DESCRIPTION
This patch updates the Travis-CI file to no longer include support for building against Go 1.4.x. The build now targets 1.5.4, 1.6.3, 1.7, and tip. Only the three most recent releases of Go will be supported and built via CI.

The patch also changes the Go version that uploads coverage to Codecov.io from 1.6.3 to 1.7.

Finally, the `run-examples` target in the Makefile now includes running example four.
