### PR TITLE
Relocated repo to codedellemc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.*-e
+.*-e
+*-e
 vendor/
 .build/
 .rpmbuild/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-go_import_path: github.com/emccode/gournal
+go_import_path: github.com/codedellemc/gournal
 
 language: go
 go:
-  - 1.5.4
   - 1.6.3
   - 1.7
   - tip

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gournal [![GoDoc](https://godoc.org/github.com/emccode/gournal?status.svg)](https://godoc.org/github.com/emccode/gournal) [![Build Status](https://travis-ci.org/emccode/gournal.svg?branch=master)](https://travis-ci.org/emccode/gournal) [![Go Report Card](https://goreportcard.com/badge/github.com/emccode/gournal)](https://goreportcard.com/report/github.com/emccode/gournal) [![codecov](https://codecov.io/gh/emccode/gournal/branch/master/graph/badge.svg)](https://codecov.io/gh/emccode/gournal)
+# Gournal [![GoDoc](https://godoc.org/github.com/codedellemc/gournal?status.svg)](https://godoc.org/github.com/codedellemc/gournal) [![Build Status](https://travis-ci.org/emccode/gournal.svg?branch=master)](https://travis-ci.org/emccode/gournal) [![Go Report Card](https://goreportcard.com/badge/github.com/codedellemc/gournal)](https://goreportcard.com/report/github.com/codedellemc/gournal) [![codecov](https://codecov.io/gh/emccode/gournal/branch/master/graph/badge.svg)](https://codecov.io/gh/emccode/gournal)
 Gournal (pronounced "Journal") is a Context-aware logging framework
 that introduces the Google [Context type](https://bgournal.golang.org/context) as
 a first-class parameter to all common log functions such as Info, Debug, etc.
@@ -12,7 +12,7 @@ favorite logger, rather existing logging frameworks such as
 easily participate as a Gournal Appender.
 
 The following
-[example](https://github.com/emccode/gournal/tree/master/examples/01/main.go)
+[example](https://github.com/codedellemc/gournal/tree/master/examples/01/main.go)
 is a simple program that uses Logrus as a Gournal Appender to emit some log
 data:
 
@@ -20,8 +20,8 @@ data:
 package main
 
 import (
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
 )
 
 func main() {
@@ -85,11 +85,11 @@ inherits one of the former.
 ## Compatability
 Gournal provides ready-to-use Appenders for the following logging frameworks:
 
-  * [Logrus](https://github.com/emccode/gournal/tree/master/logrus)
-  * [Zap](https://github.com/emccode/gournal/tree/master/zap)
-  * [Google App Engine](https://github.com/emccode/gournal/tree/master/gae)
-  * [`gournal.Logger`](https://github.com/emccode/gournal/tree/master/stdlib)
-  * [`io.Writer`](https://github.com/emccode/gournal/tree/master/iowriter)
+  * [Logrus](https://github.com/codedellemc/gournal/tree/master/logrus)
+  * [Zap](https://github.com/codedellemc/gournal/tree/master/zap)
+  * [Google App Engine](https://github.com/codedellemc/gournal/tree/master/gae)
+  * [`gournal.Logger`](https://github.com/codedellemc/gournal/tree/master/stdlib)
+  * [`io.Writer`](https://github.com/codedellemc/gournal/tree/master/iowriter)
 
 With little overhead, Gournal leverages the Google Context type to provide an
 elegant solution to the absence of features that are commonly found in
@@ -127,8 +127,8 @@ GOOS=darwin GOARCH=amd64 go install ./gae
 GOOS=darwin GOARCH=amd64 go install ./logrus
 GOOS=darwin GOARCH=amd64 go install ./stdlib
 GOOS=darwin GOARCH=amd64 go install ./zap
-./.gaesdk/1.9.40/go_appengine/goapp test -cover -coverpkg 'github.com/emccode/gournal' -c -o benchmarks/benchmarks.test ./benchmarks
-warning: no packages being tested depend on github.com/emccode/gournal
+./.gaesdk/1.9.40/go_appengine/goapp test -cover -coverpkg 'github.com/codedellemc/gournal' -c -o benchmarks/benchmarks.test ./benchmarks
+warning: no packages being tested depend on github.com/codedellemc/gournal
 benchmarks/benchmarks.test -test.run Benchmark -test.bench . -test.benchmem 2> /dev/null
 PASS
 BenchmarkNativeStdLibWithoutFields-8 	 1000000	      1024 ns/op	      16 B/op	       1 allocs/op
@@ -143,7 +143,7 @@ BenchmarkGournalStdLibWithFields-8   	  300000	      4424 ns/op	     881 B/op	  
 BenchmarkGournalLogrusWithFields-8   	  300000	      6467 ns/op	    1745 B/op	      31 allocs/op
 BenchmarkGournalZapWithFields-8      	  500000	      3160 ns/op	     641 B/op	       8 allocs/op
 BenchmarkGournalGAEWithFields-8      	  300000	      5196 ns/op	    1041 B/op	      20 allocs/op
-coverage: 21.6% of statements in github.com/emccode/gournal
+coverage: 21.6% of statements in github.com/codedellemc/gournal
 ```
 
 Please keep in mind that the above results will vary based upon the version of
@@ -177,7 +177,7 @@ that is doing the actual logging:
 
 ### Concurrent Logging Frameworks
 The following
-[example](https://github.com/emccode/gournal/tree/master/examples/02/main.go)
+[example](https://github.com/codedellemc/gournal/tree/master/examples/02/main.go)
 illustrates how to utilize the Gournal `DefaultAppender` as well as multiple
 logging frameworks in the same program:
 
@@ -185,9 +185,9 @@ logging frameworks in the same program:
 package main
 
 import (
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
-	"github.com/emccode/gournal/zap"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
+	"github.com/codedellemc/gournal/zap"
 )
 
 func main() {
@@ -238,15 +238,15 @@ Another nifty feature of Gournal is the ability to provide a Context with
 fields that will get emitted along-side every log message, whether they are
 explicitly provided with log message or not. This feature is illustrated
 in the
-[example](https://github.com/emccode/gournal/tree/master/examples/03/main.go)
+[example](https://github.com/codedellemc/gournal/tree/master/examples/03/main.go)
 below:
 
 ```go
 package main
 
 import (
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
 )
 
 func main() {
@@ -345,8 +345,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
 )
 
 // myString is a custom type that has a custom fmt.Format function.

--- a/benchmarks/gournal_bench_test.go
+++ b/benchmarks/gournal_bench_test.go
@@ -12,11 +12,11 @@ import (
 	gaetest "google.golang.org/appengine/aetest"
 	gae "google.golang.org/appengine/log"
 
-	"github.com/emccode/gournal"
-	ggae "github.com/emccode/gournal/gae"
-	glogrus "github.com/emccode/gournal/logrus"
-	glog "github.com/emccode/gournal/stdlib"
-	gzap "github.com/emccode/gournal/zap"
+	"github.com/codedellemc/gournal"
+	ggae "github.com/codedellemc/gournal/gae"
+	glogrus "github.com/codedellemc/gournal/logrus"
+	glog "github.com/codedellemc/gournal/stdlib"
+	gzap "github.com/codedellemc/gournal/zap"
 )
 
 var gaeCtx gournal.Context

--- a/examples/01/main.go
+++ b/examples/01/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
 )
 
 func main() {

--- a/examples/02/main.go
+++ b/examples/02/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
-	"github.com/emccode/gournal/zap"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
+	"github.com/codedellemc/gournal/zap"
 )
 
 func main() {

--- a/examples/03/main.go
+++ b/examples/03/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
 )
 
 func main() {

--- a/examples/04/main.go
+++ b/examples/04/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/emccode/gournal"
-	"github.com/emccode/gournal/logrus"
+	"github.com/codedellemc/gournal"
+	"github.com/codedellemc/gournal/logrus"
 )
 
 // myString is a custom type that has a custom fmt.Format function.

--- a/gae/gournal_gae.go
+++ b/gae/gournal_gae.go
@@ -7,7 +7,7 @@ import (
 
 	gae "google.golang.org/appengine/log"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 type appender int

--- a/gae/gournal_gae_test.go
+++ b/gae/gournal_gae_test.go
@@ -7,7 +7,7 @@ import (
 
 	gaetest "google.golang.org/appengine/aetest"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 var gaeCtx gournal.Context

--- a/glide.lock
+++ b/glide.lock
@@ -1,36 +1,48 @@
-hash: 5d4fb9ec67324087909cc09f86d835f828131853baa6d2f29ac8d76b3fcdd9d2
-updated: 2016-08-08T01:36:31.76546933-05:00
+hash: 8fd76425f72074620e4ade0f82b4dd42d9743826cca58bd5484cf87ef5018f39
+updated: 2016-10-27T12:40:13.905438564-05:00
 imports:
 - name: github.com/golang/protobuf
-  version: c3cefd437628a0b7d31b34fe44b3a7a540e98527
+  version: 98fa357170587e470c5f27d3c3ea0947b71eb455
   subpackages:
   - proto
 - name: github.com/Sirupsen/logrus
-  version: a283a10442df8dc09befd873fab202bf8a253d6a
+  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
+  subpackages:
+  - assert
 - name: github.com/uber-go/atomic
-  version: 0c9e689d64f004564b79d9a663634756df322902
+  version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
 - name: github.com/uber-go/zap
-  version: f6059af9adb56642e6cb2a91051feb930eba6342
+  version: f2929c57adb5be8fb03cad9a6912c509a5cb60af
 - name: golang.org/x/net
-  version: 7c62cfdcccc65f87b0120ec841012ba816fc1aec
+  version: b626cca987fa6333e5dd25baa0fd61708c145011
   subpackages:
   - context
 - name: golang.org/x/sys
-  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  version: 002cbb5f952456d0c50e0d2aff17ea5eca716979
   subpackages:
   - unix
 - name: google.golang.org/appengine
-  version: f21d98e7aefbf9ff4d5eeba05d7a925cc7ac20c3
+  version: 46239ca616842c00f41b8cbc6bbf2bd6ffbfcdad
   subpackages:
-  - log
   - aetest
   - internal
-  - internal/log
   - internal/app_identity
-  - internal/modules
   - internal/base
   - internal/datastore
+  - internal/log
+  - internal/modules
   - internal/remote_api
-devImports: []
+  - internal/user
+  - log
+  - user
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/emccode/gournal
+package: github.com/codedellemc/gournal
 import:
 
 ################################################################################

--- a/gournal.go
+++ b/gournal.go
@@ -11,7 +11,7 @@ frameworks such as Logrus, Zap, etc. can easily participate as a Gournal
 Appender.
 
 For more information on Gournal's features or how to use it, please refer
-to the project's README file or https://github.com/emccode/gournal.
+to the project's README file or https://github.com/codedellemc/gournal.
 */
 package gournal
 

--- a/logrus/gournal_logrus.go
+++ b/logrus/gournal_logrus.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 type appender struct {

--- a/logrus/gournal_logrus_test.go
+++ b/logrus/gournal_logrus_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 func TestLogrusAppenderNoFields(t *testing.T) {

--- a/stdlib/gournal_stdlib.go
+++ b/stdlib/gournal_stdlib.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 // New returns a stdlib logger that implements the Gournal Appender interface.

--- a/stdlib/gournal_stdlib_test.go
+++ b/stdlib/gournal_stdlib_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 func TestStdLibAppenderNoFields(t *testing.T) {

--- a/zap/gournal_zap.go
+++ b/zap/gournal_zap.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/uber-go/zap"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 type appender struct {

--- a/zap/gournal_zap_test.go
+++ b/zap/gournal_zap_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/emccode/gournal"
+	"github.com/codedellemc/gournal"
 )
 
 func TestZapAppenderNoFields(t *testing.T) {


### PR DESCRIPTION
This patch rewrites all of the "github.com/emccode" to "github.com/codedellemc" in source files, documentation, and other build-related content.
