### PR TITLE
Change Sirupsen to sirupsen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,11 @@ go_import_path: github.com/codedellemc/gournal
 
 language: go
 go:
-  - 1.6.3
-  - 1.7
-  - tip
+  - 1.8.3
+  - 1.9
 
 os:
   - linux
-  - osx
-
-matrix:
-  allow_failures:
-    - go: tip
-  fast_finish: true
 
 before_install:
   - git config --global 'url.https://gopkg.in/yaml.v1.insteadof' 'https://gopkg.in/yaml.v1/'
@@ -25,7 +18,6 @@ before_install:
   - make deps
 
 script:
-  - make gometalinter-all
   - make -j build
   - make -j test
 

--- a/Makefile
+++ b/Makefile
@@ -162,8 +162,8 @@ $(GAE_DEV): $(GAE_SDZ)
 	cd $(?D) && unzip -q $(?F) && cd - && touch $@
 
 GO_DEPS += $(GAE_DEV)
-./gae/gae.test: | $(GAE_DEV) $(GAE_GOA)
-./tests/gournal.test: | $(GAE_DEV) $(GAE_GOA)
+#./gae/gae.test: | $(GAE_DEV) $(GAE_GOA)
+#./tests/gournal.test: | $(GAE_DEV) $(GAE_GOA)
 
 
 ################################################################################
@@ -564,7 +564,8 @@ benchmark: ./benchmarks/benchmarks.test
 # make the benchmark coverage file order-dependent upon the GAE coverage file.
 # otherwise parallel make builds aren't happy when two GAE dev servers try to
 # spin up at the same time
-./benchmarks/benchmarks.test.out: | ./gae/gae.test.out
+./benchmarks/benchmarks.test.out:
+# | ./gae/gae.test.out
 
 ################################################################################
 ##                                 EXAMPLES                                   ##

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Instead of being Yet Another Go Log library, Gournal actually takes its
 inspiration from the Simple Logging Facade for Java
 ([SLF4J](http://www.slf4j.org/)). Gournal is not attempting to replace anyone's
 favorite logger, rather existing logging frameworks such as
-[Logrus](github.com/Sirupsen/logrus), [Zap](github.com/uber-go/zap), etc. can
+[Logrus](github.com/sirupsen/logrus), [Zap](github.com/uber-go/zap), etc. can
 easily participate as a Gournal Appender.
 
 The following

--- a/benchmarks/gotest.mk
+++ b/benchmarks/gotest.mk
@@ -1,1 +1,1 @@
-TEST_GO_./benchmarks := $(GAE_GOA)
+#TEST_GO_./benchmarks := $(GAE_GOA)

--- a/benchmarks/gournal_bench_test.go
+++ b/benchmarks/gournal_bench_test.go
@@ -1,19 +1,18 @@
 package benchmarks
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/uber-go/zap"
-	gaetest "google.golang.org/appengine/aetest"
-	gae "google.golang.org/appengine/log"
+	//gaetest "google.golang.org/appengine/aetest"
+	//gae "google.golang.org/appengine/log"
 
 	"github.com/codedellemc/gournal"
-	ggae "github.com/codedellemc/gournal/gae"
+	//ggae "github.com/codedellemc/gournal/gae"
 	glogrus "github.com/codedellemc/gournal/logrus"
 	glog "github.com/codedellemc/gournal/stdlib"
 	gzap "github.com/codedellemc/gournal/zap"
@@ -24,7 +23,7 @@ var gaeCtx gournal.Context
 func TestMain(m *testing.M) {
 	gournal.DefaultLevel = gournal.DebugLevel
 
-	var (
+	/*var (
 		err  error
 		done func()
 	)
@@ -32,11 +31,12 @@ func TestMain(m *testing.M) {
 	if gaeCtx, done, err = gaetest.NewContext(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
-	}
+	}*/
+	gaeCtx = gournal.Background()
 
 	ec := m.Run()
 
-	done()
+	//done()
 	os.Exit(ec)
 }
 
@@ -74,14 +74,14 @@ func BenchmarkNativeZapWithoutFields(b *testing.B) {
 	})
 }
 
-func BenchmarkNativeGAEWithoutFields(b *testing.B) {
+/*func BenchmarkNativeGAEWithoutFields(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			gae.Infof(gaeCtx, "Run Barry, run.")
 		}
 	})
-}
+}*/
 
 func BenchmarkGournalStdLibWithoutFields(b *testing.B) {
 	benchmarkWithoutFields(
@@ -98,9 +98,9 @@ func BenchmarkGournalZapWithoutFields(b *testing.B) {
 		zap.NewJSONEncoder(), zap.Output(os.Stderr)))
 }
 
-func BenchmarkGournalGAEWithoutFields(b *testing.B) {
+/*func BenchmarkGournalGAEWithoutFields(b *testing.B) {
 	benchmarkWithoutFields(b, ggae.New())
-}
+}*/
 
 func BenchmarkGournalStdLibWithFields(b *testing.B) {
 	benchmarkWithFields(
@@ -117,17 +117,18 @@ func BenchmarkGournalZapWithFields(b *testing.B) {
 		zap.NewJSONEncoder(), zap.Output(os.Stderr)))
 }
 
-func BenchmarkGournalGAEWithFields(b *testing.B) {
+/*func BenchmarkGournalGAEWithFields(b *testing.B) {
 	benchmarkWithFields(b, ggae.New())
-}
+}*/
 
 func newContext(a gournal.Appender) gournal.Context {
-	var ctx gournal.Context
+	/*var ctx gournal.Context
 	if a == ggae.New() {
 		ctx = gaeCtx
 	} else {
 		ctx = gournal.Background()
-	}
+	}*/
+	ctx := gournal.Background()
 	ctx = gournal.WithValue(ctx, gournal.LevelKey(), gournal.InfoLevel)
 	ctx = gournal.WithValue(ctx, gournal.AppenderKey(), a)
 	return ctx

--- a/gae/gotest.mk
+++ b/gae/gotest.mk
@@ -1,1 +1,1 @@
-TEST_GO_./gae := $(GAE_GOA)
+#TEST_GO_./gae := $(GAE_GOA)

--- a/gae/gournal_gae.go
+++ b/gae/gournal_gae.go
@@ -1,3 +1,5 @@
+// +build none
+
 // Package gae provides a Google App Engine logger that implements the Gournal
 // Appender interface.
 package gae

--- a/gae/gournal_gae_test.go
+++ b/gae/gournal_gae_test.go
@@ -1,3 +1,5 @@
+// +build none
+
 package gae
 
 import (

--- a/glide.lock
+++ b/glide.lock
@@ -1,20 +1,20 @@
-hash: 8fd76425f72074620e4ade0f82b4dd42d9743826cca58bd5484cf87ef5018f39
-updated: 2016-10-27T12:40:13.905438564-05:00
+hash: d147ce0cdf890b6a48dfb61929da9f5bf5771e2798fba0de8dd11e89fe3a9474
+updated: 2017-08-30T15:15:12.923825351-05:00
 imports:
 - name: github.com/golang/protobuf
   version: 98fa357170587e470c5f27d3c3ea0947b71eb455
   subpackages:
   - proto
-- name: github.com/Sirupsen/logrus
-  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
-- name: github.com/stretchr/testify
-  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
-  subpackages:
-  - assert
+- name: github.com/sirupsen/logrus
+  version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/uber-go/atomic
   version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506
 - name: github.com/uber-go/zap
   version: f2929c57adb5be8fb03cad9a6912c509a5cb60af
+- name: golang.org/x/crypto
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: b626cca987fa6333e5dd25baa0fd61708c145011
   subpackages:
@@ -23,6 +23,7 @@ imports:
   version: 002cbb5f952456d0c50e0d2aff17ea5eca716979
   subpackages:
   - unix
+  - windows
 - name: google.golang.org/appengine
   version: 46239ca616842c00f41b8cbc6bbf2bd6ffbfcdad
   subpackages:
@@ -39,10 +40,14 @@ imports:
   - user
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/stretchr/testify
+  version: 890a5c3458b43e6104ff5da8dfa139d013d77544
+  subpackages:
+  - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,23 +5,10 @@ import:
 ##                             Logging Frameworks                             ##
 ################################################################################
 
-  - package: github.com/Sirupsen/logrus
+  - package: github.com/sirupsen/logrus
+    version: v1.0.3
+
   - package: github.com/uber-go/zap
-  - package: google.golang.org/appengine
-    subpackages:
-    - log
-    - aetest
-
-################################################################################
-##                              Core Dependencies                             ##
-################################################################################
-
-  - package: golang.org/x/net
-    subpackages:
-    - context
-
-################################################################################
-##                              Test Dependencies                             ##
-################################################################################
-
-  - package: github.com/stretchr/testify
+    version: f2929c57adb5be8fb03cad9a6912c509a5cb60af
+  - package: github.com/uber-go/atomic
+    version: 9e99152552a6ce13fa3b2ce4a9c4fb117cca4506

--- a/logrus/gournal_logrus.go
+++ b/logrus/gournal_logrus.go
@@ -5,7 +5,7 @@ package logrus
 import (
 	"io"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 
 	"github.com/codedellemc/gournal"
 )

--- a/logrus/gournal_logrus_test.go
+++ b/logrus/gournal_logrus_test.go
@@ -3,7 +3,7 @@ package logrus
 import (
 	"testing"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/codedellemc/gournal"


### PR DESCRIPTION
This patch handles the chaos created when Sirupsen was renamed to sirupsen.

Additionally, GAE support has been disabled for the time being due to the Google AppEngine SDK being deprecated.